### PR TITLE
docs: rename trickfire-drone to match the corvus repo name

### DIFF
--- a/repo-order.json
+++ b/repo-order.json
@@ -2,7 +2,7 @@
     "general": 0,
     "trickfire-docs": 1,
     "trickfire-urc": 2,
-    "trickfire-drone": 3,
+    "corvus": 3,
     "simulations": 4,
     "ak-series": 5,
     "dashboard": 6


### PR DESCRIPTION
I updated the drone repository to rename it to 'corvus'. This small change should help reflect this in the docs.